### PR TITLE
chore: bump symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     "oat-sa/lib-em-php-client": "*",
     "oat-sa/lib-em-php-lti-client": "*",
     "oat-sa/lib-em-php-lti-events": "*",
-    "symfony/framework-bundle": "^4.4 || ^5.1",
-    "symfony/http-client": "^4.4 || ^5.1",
-    "symfony/mime": "^4.4 || ^5.1",
+    "symfony/framework-bundle": "^4.4 || ^5.1 || ^6.1 || ^7.0",
+    "symfony/http-client": "^4.4 || ^5.1 || ^6.1 || ^7.0",
+    "symfony/mime": "^4.4 || ^5.1 || ^6.1 || ^7.0",
     "symfony/psr-http-message-bridge": "^2.1"
   },
   "require-dev": {


### PR DESCRIPTION
# [AUT-3495](https://oat-sa.atlassian.net/browse/AUT-3495)

## Description 
lock on version 5 is crucial for integrate new version to new tao-studio-be - it ouse symfony 6 
but all unit tests on that repo pass on version 6 too. 
So, extend list of possible symfony versions to make it more useful 

[AUT-3495]: https://oat-sa.atlassian.net/browse/AUT-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ